### PR TITLE
fix: benchmarks auto-generation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,11 +1,9 @@
 name: Generate benchmarks
 
-on: [push, pull_request]
-
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -33,5 +31,5 @@ jobs:
         uses: EndBug/add-and-commit@v7
         with:
           default_author: user_info
-          message: "Benchmarks for $GITHUB_SHA"
+          message: "add: benchmarks"
           pull_strategy: NO-PULL

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,11 @@
 name: Generate benchmarks
 
-on:
-  push:
-    branches:
-      - main
+on: [push, pull_request]
+
+# on:
+#   push:
+#     branches:
+#       - main
 
 jobs:
   build:
@@ -19,19 +21,15 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - run: cd benchmarks
-      - run: pwd
+      - run: |
+          ls -l
+          cd benchmarks
+          pwd
+          go get -u
+          go mod tidy
+          go test -bench . -benchmem > benchmarks.txt
 
-      - name: Modify dependencies
-        env:
-          GO111MODULE: on
-        run: go get -u && go mod tidy
-
-      - name: Run benchmarks
-        env:
-          GO111MODULE: on
-        run: go test -bench . -benchmem > benchmarks.txt
-
+      - run: echo $GITHUB_SHA
       - name: Commit benchmarks
         uses: EndBug/add-and-commit@v7
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,10 +22,9 @@ jobs:
         uses: actions/checkout@v2
 
       - run: |
-          ls -l
           cd benchmarks
           pwd
-          go get -u
+          go get -u -d 
           go mod tidy
           go test -bench . -benchmem > benchmarks.txt
 

--- a/benchmarks.txt
+++ b/benchmarks.txt
@@ -1,1 +1,0 @@
-?   	github.com/akshaybharambe14/gowp	[no test files]

--- a/benchmarks/benchmarks.txt
+++ b/benchmarks/benchmarks.txt
@@ -1,8 +1,8 @@
 goos: linux
 goarch: amd64
 pkg: github.com/akshaybharambe14/gowp/benchmarks
-cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
-BenchmarkOwn-2          	  273432	      4268 ns/op	     368 B/op	       4 allocs/op
-BenchmarkWorkerPool-2   	  109678	     11306 ns/op	     721 B/op	       9 allocs/op
+cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
+BenchmarkOwn-2          	  327880	      3284 ns/op	     368 B/op	       4 allocs/op
+BenchmarkWorkerPool-2   	  139701	      8644 ns/op	     720 B/op	       9 allocs/op
 PASS
-ok  	github.com/akshaybharambe14/gowp/benchmarks	2.570s
+ok  	github.com/akshaybharambe14/gowp/benchmarks	2.414s

--- a/benchmarks/benchmarks.txt
+++ b/benchmarks/benchmarks.txt
@@ -1,0 +1,8 @@
+goos: linux
+goarch: amd64
+pkg: github.com/akshaybharambe14/gowp/benchmarks
+cpu: Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz
+BenchmarkOwn-2          	  273432	      4268 ns/op	     368 B/op	       4 allocs/op
+BenchmarkWorkerPool-2   	  109678	     11306 ns/op	     721 B/op	       9 allocs/op
+PASS
+ok  	github.com/akshaybharambe14/gowp/benchmarks	2.570s


### PR DESCRIPTION
Providing `-d` flag while downloading the dependencies solved the issue.